### PR TITLE
Missing "address out of bank range" check on instructions addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "customasm"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2018"
 authors = ["Henrique Lorenzi <https://hlorenzi.com>"]
 description = "An assembler for custom, user-defined instruction sets!"

--- a/src/asm/assembler.rs
+++ b/src/asm/assembler.rs
@@ -308,6 +308,9 @@ impl AssemblerState
 			Some(addr) => addr,
 			None => return Err(report.error_span("address overflowed valid range", span))
 		};
+
+		if bankdef_index != 0 && addr >= bankdef.addr + bankdef.size
+			{ return Err(report.error_span("address is out of bank range", span)); }
 		
 		Ok(addr)
 	}

--- a/src/test/asm.rs
+++ b/src/test/asm.rs
@@ -1008,6 +1008,8 @@ fn test_banks()
 	
 	test("", "#bankdef \"hello\" { #addr  0, #size 10 } \n #res 1 \n #addr 0 \n #res 1", Pass((4, "")));
 	test("", "#bankdef \"hello\" { #addr 10, #size 10 } \n #res 1 \n #addr 0 \n #res 1", Fail(("asm", 3, "out of bank range")));
+	test("test -> 0x12", "#bankdef \"hello\" { #addr 0, #size 3, #outp 0 } \n #res 1 \n test \n test",  Pass((4, "001212")));
+	test("test -> 0x12", "#bankdef \"hello\" { #addr 0, #size 2, #outp 0 } \n #res 1 \n test \n test",  Fail(("asm", 4, "out of bank range")));
 	
 	test("", "#bankdef \"hello\" { #addr 0, #size 4, #outp 0 }
 	          #bankdef \"world\" { #addr 0, #size 4, #outp 0 }",


### PR DESCRIPTION
Fixes issue #36 