### PR TITLE
Partial fix for issue #115: Increment $,pc inside asm{} [commits merged]

### DIFF
--- a/src/asm/state.rs
+++ b/src/asm/state.rs
@@ -1330,6 +1330,10 @@ impl State
 		fileserver: &dyn util::FileServer)
 		-> Result<expr::Value, ()>
 	{
+		// Clone the context in order to advance the logical address
+		// between instructions.
+		let mut inner_ctx = ctx.clone();
+
 		let mut result = util::BigInt::new(0, Some(0));
 		
 		let mut parser = syntax::Parser::new(Some(info.report.clone()), info.tokens);
@@ -1386,7 +1390,7 @@ impl State
 			let matches = asm::parser::match_rule_invocation(
 				&self,
 				subparser,
-				ctx.clone(),
+				inner_ctx.clone(),
 				fileserver,
 				info.report.clone())?;
 
@@ -1440,6 +1444,8 @@ impl State
 						&bigint,
 						(size, 0));
 				}
+				
+				inner_ctx.bit_offset += size;
 			}
 
 			parser.expect_linebreak()?;

--- a/tests/issue115/1.asm
+++ b/tests/issue115/1.asm
@@ -1,0 +1,21 @@
+#bits 4
+
+#ruledef
+{
+    jmp {addr: u4} => addr
+
+    asmjmp {addr: u4} => asm
+    {
+        jmp addr
+    }
+
+    op => asm
+    {
+        jmp $
+        asmjmp $
+        jmp $
+    }
+}
+
+op ; = 0x012
+op ; = 0x345

--- a/tests/issue115/2.asm
+++ b/tests/issue115/2.asm
@@ -1,0 +1,27 @@
+#bits 4
+
+#ruledef
+{
+    jmp {addr: u4} => addr
+
+    asmjmp {addr: u4} => asm
+    {
+        jmp addr
+        jmp $
+    }
+
+    op => asm
+    {
+        jmp $
+        asmjmp $
+        jmp $
+    }
+}
+
+op  ; = 0x0123
+#d asm
+{
+    op ; = 0x4567
+    op ; = 0x89ab
+}
+op  ; = 0xcdef


### PR DESCRIPTION
A simple modification of ```fn eval_asm``` where the supplied context is cloned and used instead with it's bit_offset incremented every line when that lines result size is known.