### PR TITLE
Fix 6502 instruction set

### DIFF
--- a/examples/nes/cpu6502.asm
+++ b/examples/nes/cpu6502.asm
@@ -35,19 +35,19 @@
 	and ({zaddr: u8 }), y  => 0x31 @ zaddr
 
 	asl  a               => 0x0a
-	asl <{zaddr: u8 }    => 0x07 @ zaddr
+	asl <{zaddr: u8 }    => 0x06 @ zaddr
 	asl <{zaddr: u8 }, x => 0x16 @ zaddr
-	asl  {zaddr: u8 }    => 0x07 @ zaddr
+	asl  {zaddr: u8 }    => 0x06 @ zaddr
 	asl  {zaddr: u8 }, x => 0x16 @ zaddr
 	asl  {addr:  u16}    => 0x0e @ le(addr)
 	asl  {addr:  u16}, x => 0x1e @ le(addr)
 
 	bcc {addr: cpu6502_reladdr} => 0x90 @ addr
-	bcs {addr: cpu6502_reladdr} => 0x80 @ addr
+	bcs {addr: cpu6502_reladdr} => 0xb0 @ addr
 	beq {addr: cpu6502_reladdr} => 0xf0 @ addr
 
 	bit <{zaddr: u8 } => 0x24 @ zaddr
-	bit  {addr:  u16} => 0x2C @ le(addr)
+	bit  {addr:  u16} => 0x2c @ le(addr)
 
 	bmi {addr: cpu6502_reladdr} => 0x30 @ addr
 	bne {addr: cpu6502_reladdr} => 0xd0 @ addr


### PR DESCRIPTION
I've noticed two errors in the 6502 instruction set:
- `asl zpg_addr => 0x06`: http://6502.org/tutorials/6502opcodes.html#ASL
- `bcs rel_addr => 0xB0`: http://6502.org/tutorials/6502opcodes.html#BCS

For the record, I have not checked all the op codes systematically so there might be more errors.