### PR TITLE
New #noemit directive to reduce symbol dump spam

### DIFF
--- a/src/asm/parser/file.rs
+++ b/src/asm/parser/file.rs
@@ -123,6 +123,7 @@ pub fn parse_directive(state: &mut asm::parser::State)
             "labelalign" => asm::parser::parse_directive_labelalign(state)?,
             "addr" => asm::parser::parse_directive_addr(state)?,
             "fn" => asm::parser::parse_directive_fn(state)?,
+            "noemit" => asm::parser::parse_directive_noemit(state)?,
             //"enable" => asm::parser::parse_directive_enable(state)?,
             _ =>
             {

--- a/src/asm/parser/mod.rs
+++ b/src/asm/parser/mod.rs
@@ -9,6 +9,7 @@ mod data;
 mod addr_related;
 mod include;
 mod function;
+mod noemit;
 
 
 pub use self::state::State;
@@ -22,3 +23,4 @@ pub use self::data::*;
 pub use self::addr_related::*;
 pub use self::include::*;
 pub use self::function::*;
+pub use self::noemit::*;

--- a/src/asm/parser/noemit.rs
+++ b/src/asm/parser/noemit.rs
@@ -1,0 +1,24 @@
+use crate::*;
+
+pub fn parse_directive_noemit(
+    state: &mut asm::parser::State)
+    -> Result<(), ()>
+{
+    let tk_status = state.parser.expect(syntax::TokenKind::Identifier)?;
+    let status = tk_status.excerpt.as_ref().unwrap().to_ascii_lowercase();
+
+    match status.as_ref()
+    {
+        "on" => state.asm_state.is_noemit = true,
+        "off" => state.asm_state.is_noemit = false,
+        _ =>
+        {
+            state.report.error_span(
+                "unknown noemit state",
+                &tk_status.span,
+            );
+            return Err(());
+        }
+    }
+    Ok(())
+}

--- a/src/asm/parser/symbol.rs
+++ b/src/asm/parser/symbol.rs
@@ -82,7 +82,8 @@ pub fn parse_symbol(
         value,
         state.asm_state.cur_bank,
         state.report.clone(), 
-        &span)?;
+        &span,
+        !state.asm_state.is_noemit)?;
 
     Ok(())
 }

--- a/src/asm/state.rs
+++ b/src/asm/state.rs
@@ -26,6 +26,7 @@ pub struct State
 	pub cur_bank: BankRef,
 	pub cur_wordsize: usize,
 	pub cur_labelalign: usize,
+	pub is_noemit: bool,
 }
 
 
@@ -217,6 +218,7 @@ impl State
 			cur_bank: BankRef { index: 0 },
 			cur_wordsize: 8,
 			cur_labelalign: 0,
+			is_noemit: false,
 		};
 
 		state.create_bank(asm::Bank::new_default(), diagn::RcReport::new()).unwrap();


### PR DESCRIPTION
Here is my initial implementation of a `#noemit` directive, it may take `on` or `off`. Symbols which are declared after a `#noemit on`, but before `#noemit off` will not be included in the symbol dump of that assembly. So for example, in the following snippet, `FOO` and `QUX` will be in the symbol dump, but `BAR` and `BAZ` will not be.
```
FOO= 0
#noemit on
BAR = 1
BAZ = 2
#noemit off
QUX = 3
```