### PR TITLE
Fixed filename in addrspan output

### DIFF
--- a/src/util/bitvec_format.rs
+++ b/src/util/bitvec_format.rs
@@ -514,10 +514,11 @@ impl util::BitVec
             {
                 let (line_start, col_start) = counter.get_line_column_at_index(start);
                 let (line_end, col_end) = counter.get_line_column_at_index(end);
+                let filename = fileserver.get_filename(span.span.file_handle);
 
                 result.push_str(
                     &format!("{}:{}:{}:{}:{}",
-                        &span.span.file_handle,
+                        filename,
                         line_start, col_start,
                         line_end, col_end));
             }


### PR DESCRIPTION
I have been using `customasm` for my homebrew CPU, and it has been great!
I recently updated to the latest version and found an issue with the `addrspan` file format.

It was putting a number (the file handle) in the output instead of the filename / path.

I'm not a Rust developer, but I made the change and tested it locally.