### PR TITLE
Custom assert messages

### DIFF
--- a/src/expr/eval.rs
+++ b/src/expr/eval.rs
@@ -219,6 +219,29 @@ impl<'a> EvalFunctionQuery<'a>
 			Ok(())
 		}
 	}
+
+	pub fn ensure_min_max_arg_number(
+		&mut self,
+		minimum_expected_arg_number: usize,
+		maximum_expected_arg_number: usize,
+	) -> Result<(), ()> {
+		if !((self.args.len() >= minimum_expected_arg_number)
+			&& (self.args.len() <= maximum_expected_arg_number))
+		{
+			self.report.error_span(
+				format!(
+					"function expected {} to {} arguments (but got {})",
+					minimum_expected_arg_number,
+					maximum_expected_arg_number,
+					self.args.len()
+				),
+				self.span,
+			);
+			Err(())
+		} else {
+			Ok(())
+		}
+	}
 }
 
 

--- a/tests/rule_assert/err_args_too_few.asm
+++ b/tests/rule_assert/err_args_too_few.asm
@@ -1,0 +1,10 @@
+#ruledef test
+{
+    ld {x} =>
+    {
+        assert()
+        0x55 @ x`8
+    }
+}
+
+ld 0x15 ; error: failed / note:_:3: within / error:_:5: expected 1 to 2 arguments

--- a/tests/rule_assert/err_args_too_many.asm
+++ b/tests/rule_assert/err_args_too_many.asm
@@ -1,0 +1,10 @@
+#ruledef test
+{
+    ld {x} =>
+    {
+        assert(x < 0x10, "your custom message!", "another message!")
+        0x55 @ x`8
+    }
+}
+
+ld 0x15 ; error: failed / note:_:3: within / error:_:5: expected 1 to 2 arguments

--- a/tests/rule_assert/err_condition_wrong_type.asm
+++ b/tests/rule_assert/err_condition_wrong_type.asm
@@ -1,0 +1,10 @@
+#ruledef test
+{
+    ld {x} =>
+    {
+        assert("your custom message!", x < 0x10)
+        0x55 @ x`8
+    }
+}
+
+ld 0x15 ; error: failed / note:_:3: within / error:_:5: expected boolean

--- a/tests/rule_assert/err_message.asm
+++ b/tests/rule_assert/err_message.asm
@@ -1,0 +1,10 @@
+#ruledef test
+{
+    ld {x} =>
+    {
+        assert(x < 0x10, "your custom message!")
+        0x55 @ x`8
+    }
+}
+
+ld 0x15 ; error: failed / note:_:3: within / error:_:5: your custom message!

--- a/tests/rule_assert/err_message_wrong_type.asm
+++ b/tests/rule_assert/err_message_wrong_type.asm
@@ -1,0 +1,10 @@
+#ruledef test
+{
+    ld {x} =>
+    {
+        assert(x < 0x10, 0x1234)
+        0x55 @ x`8
+    }
+}
+
+ld 0x15 ; error: failed / note:_:3: within / error:_:5: expected string

--- a/tests/rule_assert/ok_message.asm
+++ b/tests/rule_assert/ok_message.asm
@@ -1,0 +1,11 @@
+#ruledef test
+{
+    ld {x} =>
+    {
+        assert(x < 0x10, "your custom message!")
+        0x55 @ x`8
+    }
+}
+
+ld 0x5 ; = 0x5505
+ld -0x20 ; = 0x55e0


### PR DESCRIPTION
The builtin `assert` now takes a string as an optional second argument. When present, it will be used as a custom error message if the condition fails.

*ex* without custom message:
```error: failed to resolve instruction
  --> example.asm:10:1:
 8 | } 
 9 |  
10 | ld 0x70 ; error: failed / note:_:3: within / error:_:5: assertion 
   | ^^^^^^^                                                            
11 | 
   + note: within `test`, rule 0
   --> example.asm:3:5:
  3 |     ld {x} => 
    |     ^^^^^^     
    + error: assertion failed
    --> example.asm:5:9:
   3 |     ld {x} => 
   4 |     { 
   5 |         assert(x < 0x10) 
     |         ^^^^^^^^^^^^^^^^  
   6 |         0x55 @ x`8 
   7 |     } 
```
*ex* with custom message:
```
  --> example.asm:10:1:
 8 | } 
 9 |  
10 | ld 0x70 ; error: failed / note:_:3: within / error:_:5: assertion 
   | ^^^^^^^                                                            
11 | 
   + note: within `test`, rule 0
   --> example.asm:3:5:
  3 |     ld {x} => 
    |     ^^^^^^     
    + error: assertion failed: Your assertion has failed
    --> example.asm:5:9:
   3 |     ld {x} => 
   4 |     { 
   5 |         assert(x < 0x10, "Your assertion has failed") 
     |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^  
   6 |         0x55 @ x`8 
   7 |     } 
```