### PR TITLE
Add support for including slices of binary files

### DIFF
--- a/src/expr/expression.rs
+++ b/src/expr/expression.rs
@@ -361,7 +361,7 @@ impl Value
 			_ =>
 			{
 				report.error_span(
-					"expected integer",
+					"expected non-negative integer",
 					span);
 
 				Err(())
@@ -394,7 +394,7 @@ impl Value
 			_ =>
 			{
 				report.error_span(
-					"expected integer",
+					"expected non-negative integer",
 					span);
 
 				Err(())
@@ -430,7 +430,7 @@ impl Value
 			_ =>
 			{
 				report.error_span(
-					"expected integer",
+					"expected positive integer",
 					span);
 
 				Err(())

--- a/src/test/expr.rs
+++ b/src/test/expr.rs
@@ -275,8 +275,8 @@ fn test_ops_slice()
 	test("-1[1000:1000]", Pass(expr::Value::make_integer(util::BigInt::new(1, Some(1)))));
 	
 	test("0x00[0:7]", Fail(("test", 1, "invalid")));
-	test("0x00`{}", Fail(("test", 1, "expected integer")));
-	test("0x00`(1 == 2)", Fail(("test", 1, "expected integer")));
+	test("0x00`{}", Fail(("test", 1, "expected non-negative integer")));
+	test("0x00`(1 == 2)", Fail(("test", 1, "expected non-negative integer")));
 	test("0x00`-1", Fail(("test", 1, "expected expression")));
 	test("0x00`(-1)", Fail(("test", 1, "out of supported range")));
 	test("0x00[7:-1]", Fail(("test", 1, "out of supported range")));

--- a/src/util/bigint.rs
+++ b/src/util/bigint.rs
@@ -341,9 +341,19 @@ impl BigInt
             panic!("invalid slice range");
         }
 
+        if let Some(size) = self.size
+        {
+            if self.bigint.sign() != num_bigint::Sign::Minus &&
+                left == size &&
+                right == 0
+            {
+                return self.clone();
+            }
+        }
+
         let mut result = BigInt::from(0);
 
-        for i in 0..(left - right)
+        for i in (0..(left - right)).rev()
         {
             result.set_bit(
                 i,

--- a/tests/incbin/err_end_after_eof.asm
+++ b/tests/incbin/err_end_after_eof.asm
@@ -1,0 +1,1 @@
+#d incbin("data1.bin",2,4) ; error: failed / error: ends after EOF (2 + 4 > 5)

--- a/tests/incbin/err_start_after_eof.asm
+++ b/tests/incbin/err_start_after_eof.asm
@@ -1,0 +1,1 @@
+#d incbin("data1.bin",5) ; error: failed / error: starts after EOF (5 >= 5)

--- a/tests/incbin/err_too_few_arguments.asm
+++ b/tests/incbin/err_too_few_arguments.asm
@@ -1,1 +1,1 @@
-#d incbin() ; error: failed / error: expected 1 argument
+#d incbin() ; error: failed / error: expected 1 to 3 arguments

--- a/tests/incbin/err_too_many_args.asm
+++ b/tests/incbin/err_too_many_args.asm
@@ -1,1 +1,1 @@
-#d incbin("data1.bin", "data2.bin") ; error: failed / error: expected 1 argument
+#d incbin("data1.bin", 1, 2, 3) ; error: failed / error: expected 1 to 3 arguments

--- a/tests/incbin/err_wrong_usage.asm
+++ b/tests/incbin/err_wrong_usage.asm
@@ -1,0 +1,1 @@
+#d incbin("data1.bin", "data2.bin") ; error: failed / error: expected non-negative integer

--- a/tests/incbin/ok_start.asm
+++ b/tests/incbin/ok_start.asm
@@ -1,0 +1,1 @@
+#d incbin("data1.bin",1) ; = 0x656c6c6f

--- a/tests/incbin/ok_start_size.asm
+++ b/tests/incbin/ok_start_size.asm
@@ -1,0 +1,1 @@
+#d incbin("data1.bin",2,2) ; = 0x6c6c

--- a/tests/incbinstr/err_end_after_eof.asm
+++ b/tests/incbinstr/err_end_after_eof.asm
@@ -1,0 +1,1 @@
+#d incbinstr("data1.txt",4,8) ; error: failed / error: ends after EOF (4 + 8 > 8)

--- a/tests/incbinstr/err_start_after_eof.asm
+++ b/tests/incbinstr/err_start_after_eof.asm
@@ -1,0 +1,1 @@
+#d incbinstr("data1.txt",8) ; error: failed / error: starts after EOF (8 >= 8)

--- a/tests/incbinstr/err_too_few_args.asm
+++ b/tests/incbinstr/err_too_few_args.asm
@@ -1,1 +1,1 @@
-#d incbinstr() ; error: failed / error: expected 1 argument
+#d incbinstr() ; error: failed / error: expected 1 to 3 arguments

--- a/tests/incbinstr/err_too_many_args.asm
+++ b/tests/incbinstr/err_too_many_args.asm
@@ -1,1 +1,1 @@
-#d incbinstr("data1.txt", "data2.txt") ; error: failed / error: expected 1 argument
+#d incbinstr("data1.txt",0,1,2) ; error: failed / error: expected 1 to 3 arguments

--- a/tests/incbinstr/err_wrong_usage.asm
+++ b/tests/incbinstr/err_wrong_usage.asm
@@ -1,0 +1,1 @@
+#d incbinstr("data1.txt", "data2.txt") ; error: failed / error: expected non-negative integer

--- a/tests/incbinstr/ok_start.asm
+++ b/tests/incbinstr/ok_start.asm
@@ -1,0 +1,1 @@
+#d incbinstr("data3.txt",4) ; =0xaf5a

--- a/tests/incbinstr/ok_start_size.asm
+++ b/tests/incbinstr/ok_start_size.asm
@@ -1,0 +1,1 @@
+#d incbinstr("data3.txt",8,8) ; =0xf5

--- a/tests/inchexstr/err_end_after_eof.asm
+++ b/tests/inchexstr/err_end_after_eof.asm
@@ -1,0 +1,1 @@
+#d inchexstr("data1.txt",2,4) ; error: failed / error: ends after EOF (2 + 4 > 4)

--- a/tests/inchexstr/err_start_after_eof.asm
+++ b/tests/inchexstr/err_start_after_eof.asm
@@ -1,0 +1,1 @@
+#d inchexstr("data1.txt",4) ; error: failed / error: starts after EOF (4 >= 4)

--- a/tests/inchexstr/err_too_few_args.asm
+++ b/tests/inchexstr/err_too_few_args.asm
@@ -1,1 +1,1 @@
-#d inchexstr() ; error: failed / error: expected 1 argument
+#d inchexstr() ; error: failed / error: expected 1 to 3 arguments

--- a/tests/inchexstr/err_too_many_args.asm
+++ b/tests/inchexstr/err_too_many_args.asm
@@ -1,1 +1,1 @@
-#d inchexstr("data1.txt", "data2.txt") ; error: failed / error: expected 1 argument
+#d inchexstr("data1.txt",0,1,2) ; error: failed / error: expected 1 to 3 arguments

--- a/tests/inchexstr/err_wrong_usage.asm
+++ b/tests/inchexstr/err_wrong_usage.asm
@@ -1,0 +1,1 @@
+#d inchexstr("data1.txt", "data2.txt") ; error: failed / error: expected non-negative integer

--- a/tests/inchexstr/ok_start.asm
+++ b/tests/inchexstr/ok_start.asm
@@ -1,0 +1,1 @@
+#d inchexstr("data3.txt",4) ; =0x5a5af5a5a0000

--- a/tests/inchexstr/ok_start_size.asm
+++ b/tests/inchexstr/ok_start_size.asm
@@ -1,0 +1,1 @@
+#d inchexstr("data3.txt",8,2) ; =0xf5


### PR DESCRIPTION
Adds 2 new forms of `incbin`:

- `incbin(relative_filename, start)`: includes `relative_filename` starting from offset `start`
- `incbin(relative_filename, start, size)`: includes `size` bytes from `relative_filename` starting from offset `start`

I'd also like to make `incbinstr` and `inchexstr` work similarly, but I'm not sure how to make it work (extra clarification for PR message that wasn't in the commit message: `incbinstr` and `inchexstr` go straight from a bitvec to a bigint with no intervening `Vec<u8>` step, so I can't slice it as easily as I can `incbin`).

When #191 gets merged, `ensure_inc_args` can be replaced with a call to `query.ensure_min_max_arg_number(1,3)?;`. Since I don't have that merged locally, I just wrote a quick and dirty function to do it.