### PR TITLE
Fix panic when incbin'ing an empty file

### DIFF
--- a/src/asm/resolver/eval_fn.rs
+++ b/src/asm/resolver/eval_fn.rs
@@ -176,6 +176,11 @@ fn eval_builtin_incbin(
         }
     };
 
+    if bytes.len() == 0
+    {
+        return Ok(expr::Value::make_integer(util::BigInt::from_bytes_be(&[])));
+    }
+
     if start >= bytes.len()
     {
         query.report.error_span(


### PR DESCRIPTION
If you incbin an empty file, the code I wrote for including ranges assumes you gave it an invalid start and tries to report an error on an argument that wasn't provided. This fixes that by short-circuiting to returning an empty value if there are no bytes in the file.