### PR TITLE
Version fallback

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -25,10 +25,9 @@ pub fn generate_git_info()
         .arg("--pretty=format:%h")
         .arg("--no-patch");
 
-    let hash = run_command_and_get_output(&mut command_hash)
-        .unwrap_or("??????".to_string());
-
-    println!("cargo:rustc-env=CUSTOMASM_COMMIT_HASH={}", hash);
+    if let Ok(hash) = run_command_and_get_output(&mut command_hash) {
+        println!("cargo:rustc-env=CUSTOMASM_COMMIT_HASH={}", hash);
+    }
 
     let mut command_date = Command::new("git");
     command_date
@@ -36,10 +35,9 @@ pub fn generate_git_info()
         .arg("--pretty=format:%cs")
         .arg("--no-patch");
 
-    let date = run_command_and_get_output(&mut command_date)
-        .unwrap_or("????-??-??".to_string());
-    
-    println!("cargo:rustc-env=CUSTOMASM_COMMIT_DATE={}", date);
+    if let Ok(date) = run_command_and_get_output(&mut command_date) {
+        println!("cargo:rustc-env=CUSTOMASM_COMMIT_DATE={}", date);
+    }
 }
 
 

--- a/src/driver.rs
+++ b/src/driver.rs
@@ -909,16 +909,20 @@ fn print_version_short()
 {
 	let version = env!("CUSTOMASM_VERSION");
 	let target = env!("CUSTOMASM_TARGET");
-	let commit_hash = env!("CUSTOMASM_COMMIT_HASH");
-	let commit_date = env!("CUSTOMASM_COMMIT_DATE");
+	let commit_hash = option_env!("CUSTOMASM_COMMIT_HASH");
+	let commit_date = option_env!("CUSTOMASM_COMMIT_DATE");
+
+	let detail = [commit_date, commit_hash, Some(target)]
+		.into_iter()
+		.flatten()
+		.collect::<Vec::<_>>()
+		.join(", ");
 
 	println!(
-		"{} {} ({}, {}, {})",
+		"{} {} ({})",
 		env!("CARGO_PKG_NAME"),
 		version,
-		commit_date,
-		commit_hash,
-		target);
+		detail);
 }
 
 

--- a/src/webasm/mod.rs
+++ b/src/webasm/mod.rs
@@ -63,10 +63,17 @@ pub unsafe extern fn wasm_assemble(
 #[no_mangle]
 pub unsafe extern fn wasm_get_version() -> *mut String
 {
-	wasm_string_new_with(format!(
-		"{} ({})",
-		env!("CUSTOMASM_VERSION"),
-		env!("CUSTOMASM_COMMIT_HASH")))
+	let version =
+		if let Some(hash) = option_env!("CUSTOMASM_COMMIT_HASH") {
+			format!(
+				"{} ({})",
+				env!("CUSTOMASM_VERSION"),
+				hash)
+		}
+		else {
+			env!("CUSTOMASM_VERSION").to_string()
+		};
+	wasm_string_new_with(version)
 }
 
 


### PR DESCRIPTION
The replacement code of Vergen removal (3d2ed07dbd8e191409f69c69d70c31384e639f5b) introduced an unimportant regression: reporting slightly confusing version information, in case Git commit details were unavailable when CustomAsm was compiled. For example, when installed using `cargo install` command.

Older versions reported the information as:
> customasm v0.13.9 (x86_64-unknown-linux-gnu)

While the new one shows:
> customasm v0.13.11 (????-??-??, ??????, x86_64-unknown-linux-gnu)

This patch restores previous behavior.

Also added similar handling in Wasm builds for completeness.