### PR TITLE
Allow colon symbol for ruledef

### DIFF
--- a/src/syntax/token.rs
+++ b/src/syntax/token.rs
@@ -104,7 +104,8 @@ impl TokenKind
 		self == TokenKind::Tilde ||
 		self == TokenKind::At ||
 		self == TokenKind::LessThan ||
-		self == TokenKind::GreaterThan
+		self == TokenKind::GreaterThan ||
+		self == TokenKind::Colon
 	}
 	
 	


### PR DESCRIPTION
At the moment it is not possible to create a rule like this:
```
#subruledef reg_addr
{
    [{ hi: register }:{ lo: register }] => hi @ lo
}
```
If you need an instruction like:
```asm
AAA [rA:rB]
```
It fails with error:
```
32 | #subruledef reg_addr
33 | {
34 |     [{ hi: register }:{ lo: register }] => hi @ lo
   |                      ^
35 | }
36 |
```

This PR adds colon symbol to allowed tokens for ruledef. I tested changes locally with my mini ISA and it worked